### PR TITLE
add:simple_calendarの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
+gem 'simple_calendar'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simple_calendar (3.1.0)
+      rails (>= 6.1)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -335,6 +337,7 @@ DEPENDENCIES
   rails (~> 7.2.1)
   rubocop-rails-omakase
   selenium-webdriver
+  simple_calendar
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,1 +1,36 @@
 @import "tailwindcss";
+
+@layer components {
+  .simple-calendar .calendar-heading {
+    @apply mb-4 text-center;
+  }
+
+  .simple-calendar .calendar-title {
+    @apply text-xl font-bold text-orange-800;
+  }
+
+  .simple-calendar nav a {
+    @apply mx-2 px-3 py-1 text-sm font-bold;
+  }
+
+  .simple-calendar table {
+    @apply w-full border-collapse bg-orange-50;
+  }
+
+  .simple-calendar th {
+    @apply border border-orange-200 bg-orange-100 py-2 text-sm font-bold text-orange-800;
+  }
+
+  .simple-calendar td {
+    @apply border border-orange-200 h-10 p-1 align-top;
+  }
+
+  .simple-calendar .today {
+    @apply bg-orange-200;
+  }
+
+  .simple-calendar .wday-0,
+  .simple-calendar .wday-6 {
+    @apply bg-orange-100;
+  }
+}

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class StaticPagesController < ApplicationController
-  def top; end
+  def top
+    @events = []  # ← 将来 Event.all に置き換える
+  end
 end

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -28,7 +28,21 @@
     </span>
   </h2>
 
-  <%= image_tag "12gatu.png", class: "w-96 h-auto mx-auto block border-4 border-orange-100" %>
+<div class="mx-auto mb-8 w-96">
+  <%= month_calendar events: @events do |date, events| %>
+    <div class="flex flex-col h-full">
+      <span class="text-sm font-bold text-orange-700">
+        <%= date.day %>
+      </span>
+
+      <% events.each do |event| %>
+        <span class="mt-1 rounded bg-orange-200 px-1 text-xs">
+          <%= event.title %>
+        </span>
+      <% end %>
+    </div>
+  <% end %>
+</div>
 
   <div class="mb-4 text-center">
     <a>注）営業時間は10時〜16時になります。</a>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -15,7 +15,21 @@
   </span>
 </h2>
 
-<%= image_tag "2026:1.png", class: "w-96 h-auto mx-auto block mb-8 border-4 border-orange-100" %>
+<div class="mx-auto mb-8 w-96">
+  <%= month_calendar events: @events do |date, events| %>
+    <div class="flex flex-col h-full">
+      <span class="text-sm font-bold text-orange-700">
+        <%= date.day %>
+      </span>
+
+      <% events.each do |event| %>
+        <span class="mt-1 rounded bg-orange-200 px-1 text-xs">
+          <%= event.title %>
+        </span>
+      <% end %>
+    </div>
+  <% end %>
+</div>
 
 <div class="text-center mb-10">
   <%= link_to "ご予約はこちら", new_reservation_path, class: "bg-orange-100 hover:bg-orange-400 font-bold py-2 px-4 rounded inline-block border-2 border-orange-200" %>


### PR DESCRIPTION

### gem sinple_calendarを使いカレンダーを画像表示から変更

変更理由
- 月ごとに画像の変更をしなくてよくなる
- 今後イベントの設定など拡張していくため