### PR TITLE
45 top calendar closed dates preload

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,7 @@
 class StaticPagesController < ApplicationController
   def top
     @events = CalendarEvent.all
+    @closed_dates = CalendarEvent.where(kind: :closed).pluck(:event_date)
 
     today = Date.current
     now = Time.zone.now

--- a/app/views/shared/_business_calendar.html.erb
+++ b/app/views/shared/_business_calendar.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <%= month_calendar events: events do |date, day_events| %>
-    <% closed = CalendarEvent.closed_on?(date) %>
+    <% closed = closed_dates.include?(date) %>
     <% reservable = !closed && date >= min_reservable_date && date <= max_reservable_date %>
 
     <div class="flex flex-col h-full gap-1">
@@ -23,6 +23,7 @@
           <%= date.day %>
         </span>
       <% end %>
+
       <% day_events.each do |event| %>
         <span class="mt-1 rounded px-1 text-xs <%= event.closed? ? 'bg-gray-200 text-gray-600' : 'bg-orange-200 text-gray-800' %>">
           <%= event.title %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -29,6 +29,7 @@
   <!-- 営業日 -->
   <%= render "shared/business_calendar",
     events: @events,
+    closed_dates: @closed_dates,
     title: "営業日カレンダー",
     note: "※開催は1日2回（10:00 / 13:00）です",
     min_reservable_date: @min_reservable_date,


### PR DESCRIPTION
## 概要
トップページの営業日カレンダー表示処理をリファクタリングしました。

これまでカレンダー描画時に CalendarEvent.closed_on?(date) を日付ごとに呼び出しており、
日数分のDBアクセスが発生する構成となっていました。

今回、休業日の event_date を controller 側で事前取得し、
view ではそのデータを参照して判定する形に変更することで、
N+1の発生を防ぎました。

## 変更内容
- StaticPagesController#top で休業日の event_date を事前取得
- top.html.erb から partial に closed_dates を渡すよう修正
- partial 内の休業日判定を include? に変更
- day_events は表示用途のため削除せず維持

## 変更理由
- カレンダー描画時のDBアクセス回数削減（N+1回避）
- controller / view の責務分離
- 表示ロジックと判定ロジックの整理

## 確認項目
- [x] トップページが正常に表示される
- [x] 営業日カレンダーが表示される
- [x] 「開催」「休み」の表示が崩れていない
- [x] 予約可能日の判定が従来通り動作する
- [x] DBアクセスが日付ごとに発生しない構成になっている