### PR TITLE
47 refactor calendar closed dates method

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -21,7 +21,7 @@ class ReservationsController < ApplicationController
     @min_reservable_date = now >= deadline ? today + 2.days : today + 1.day
     @max_reservable_date = today + 60.days
 
-    @calendar_closed_dates = CalendarEvent.where(kind: :closed).pluck(:event_date)
+    @calendar_closed_dates = CalendarEvent.closed_dates
 
     range = @min_reservable_date..@max_reservable_date
     @blocked_closed_dates = CalendarEvent.closed_dates_between(range)
@@ -38,7 +38,7 @@ class ReservationsController < ApplicationController
     @min_reservable_date = now >= deadline ? today + 2.days : today + 1.day
     @max_reservable_date = today + 60.days
 
-    @calendar_closed_dates = CalendarEvent.where(kind: :closed).pluck(:event_date)
+    @calendar_closed_dates = CalendarEvent.closed_dates
 
     range = @min_reservable_date..@max_reservable_date
     @blocked_closed_dates = CalendarEvent.closed_dates_between(range)

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -9,7 +9,7 @@ class StaticPagesController < ApplicationController
     @min_reservable_date = now >= deadline ? today + 2.days : today + 1.day
     @max_reservable_date = today + 60.days
 
-    @calendar_closed_dates = CalendarEvent.where(kind: :closed).pluck(:event_date)
+    @calendar_closed_dates = CalendarEvent.closed_dates
   end
 
   def terms; end

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -12,12 +12,17 @@ class CalendarEvent < ApplicationRecord
     open? ? "開催" : "休み"
   end
 
-  # ✅ 追加：休み判定
+  # バリデーション用：指定日が休業日か判定する
+  def self.closed_on?(date)
+    where(event_date: date.to_date, kind: :closed).exists?
+  end
+
+  # カレンダー表示用：休業日一覧を返す
   def self.closed_dates
     where(kind: :closed).pluck(:event_date)
   end
 
-  # ✅ 追加：休み日一覧（配列で返す）
+  # フォーム判定用：指定範囲内の休業日一覧を返す
   def self.closed_dates_between(range)
     from = range.begin.to_date.beginning_of_day
     to   = range.end.to_date.end_of_day

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -13,8 +13,8 @@ class CalendarEvent < ApplicationRecord
   end
 
   # ✅ 追加：休み判定
-  def self.closed_on?(date)
-    where(event_date: date, kind: :closed).exists?
+  def self.closed_dates
+    where(kind: :closed).pluck(:event_date)
   end
 
   # ✅ 追加：休み日一覧（配列で返す）


### PR DESCRIPTION
## 概要
カレンダーの休業日取得ロジックをモデルに集約し、コントローラー内のクエリ処理を整理しました。  
あわせて、予約バリデーションで使用している休業日判定メソッドをモデルに定義しました。

---

## 変更内容

### ■ モデル（CalendarEvent）

休業日に関する処理をモデルに集約しました。

- `closed_dates`
  - 休業日一覧を取得

- `closed_dates_between(range)`
  - 指定範囲内の休業日を取得

- `closed_on?(date)`
  - 指定日が休業日かどうかを判定（バリデーション用）

---

### ■ コントローラー

休業日取得処理をモデルメソッドに置き換えました。

- カレンダー表示用

```ruby
@calendar_closed_dates = CalendarEvent.closed_dates
```

---

## 変更前の課題

- 休業日取得のクエリがコントローラー内に複数存在していた  
- 同様のロジックが分散し、保守性が低い状態だった  

---

## 改善点

- クエリロジックをモデルに集約し、責務を整理  
- コントローラーの記述を簡潔にした  
- 休業日判定ロジック（closed_on?）を明示的に定義し、バリデーションとの整合性を確保  

---

## 影響範囲

- トップページのカレンダー表示  
- 予約作成時のバリデーション  

※ 挙動変更はなく、リファクタリングのみです  

---

## 確認方法

1. トップページのカレンダーに休業日が正しく表示されること  
2. 予約画面で休業日が選択できないこと  
3. 休業日を指定した場合に予約が作成されないこと  
